### PR TITLE
fixes a small display-bug

### DIFF
--- a/css/homer.css
+++ b/css/homer.css
@@ -452,6 +452,11 @@
     box-shadow: inset 2px 0px 0px 0px rgba(247,254,140,1);
 }
 
+#homer .head .mouth
+{
+    border: 0;
+}
+
 #homer .head .mouth1
 {
     top: 86px;


### PR DESCRIPTION
Homer did have a 1px border-pixel in his top-left corner on http://pattle.github.io/simpsons-in-css/ (tested in Chrome and Firefox on Windows 8.1)
