### PR TITLE
Improve Bart's hair outline

### DIFF
--- a/css/bart.css
+++ b/css/bart.css
@@ -34,7 +34,7 @@
     border-left: 1px solid #110b00;
     -webkit-border-radius: 2px 0 0 0;
     -moz-border-radius: 2px 0 0 0;
-    border-radius: 2px 0 0 0;
+    border-radius: 0;
 }
 
 #bart .head .hair1


### PR DESCRIPTION
Slightly improves Bart's hair on nice Mac screen, more  significant on Windows machine's screen
before:
<img width="132" alt="screen shot 2016-05-12 at 4 54 03 pm" src="https://cloud.githubusercontent.com/assets/14310/15230192/75808748-1862-11e6-9d7b-ed1d8bba51dc.png">
after:
<img width="118" alt="screen shot 2016-05-12 at 4 53 48 pm" src="https://cloud.githubusercontent.com/assets/14310/15230201/812de112-1862-11e6-83e5-73a6e690c61c.png">
